### PR TITLE
fix: scope launcher and filter-add button to scene-context pages

### DIFF
--- a/multiView.js
+++ b/multiView.js
@@ -242,10 +242,20 @@
 
     // ?"??"? Floating launcher ?"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"??"?
 
+    // Whitelist of paths where the floating launcher is allowed to mount.
+    // Without this, the launcher follows the user into Settings, Tasks,
+    // Logs, System etc. — pages where queueing scenes is not a thing.
+    function isLauncherAllowedHere() {
+        return /^\/scenes(\/|$)/.test(window.location.pathname);
+    }
+
     function updateLauncher() {
         let el = document.getElementById('mv-launcher');
 
-        if (!getPickingMode()) { if (el) el.remove(); return; }
+        if (!isLauncherAllowedHere() || !getPickingMode()) {
+            if (el) el.remove();
+            return;
+        }
 
         if (!el) {
             el = document.createElement('div');
@@ -296,8 +306,20 @@
         btn.classList.toggle('mv-filter-has-slots', count > 0);
     }
 
+    // The filter-add button only makes sense when the page is currently
+    // filtering scenes. URL whitelist for routes that *can* show scenes
+    // (excluding the single-scene detail page), AND a runtime check that
+    // scene cards are actually rendered (handles e.g. a performer's
+    // Images tab where the toolbar exists but no scene cards do).
+    function isFilterAddBtnAllowedHere() {
+        const p = window.location.pathname;
+        if (/^\/scenes\/\d+/.test(p)) return false;
+        if (!/^\/(scenes|performers|studios|tags|groups|movies|galleries)(\/|$)/.test(p)) return false;
+        return !!document.querySelector('.scene-card');
+    }
+
     function injectFilterBtn() {
-        if (window.location.pathname.match(/^\/scenes\/\d+/) || !getPickingMode()) {
+        if (!isFilterAddBtnAllowedHere() || !getPickingMode()) {
             document.getElementById('mv-filter-add-btn')?.remove();
             return;
         }


### PR DESCRIPTION
## Summary
- `#mv-launcher` no longer follows users into Settings, Tasks, Logs, System and other unrelated pages — a path whitelist (`^/scenes(/|$)`) gates the mount.
- `#mv-filter-add-btn` no longer injects on tabs where the current filter context isn't scenes (e.g. a performer's Images tab) — added a URL whitelist plus a runtime `.scene-card` check.

Both are pure scoping fixes; existing functionality on `/scenes` is unchanged.

## Repro (before)
1. Toggle picking mode on.
2. Navigate to **Settings** → `#mv-launcher` is visible bottom-right.
3. Navigate to a **performer detail → Images** tab → `#mv-filter-add-btn` appears in the filter toolbar even though the filter is for images.

## After
1. Launcher is removed on any non-`/scenes*` route.
2. Filter-add button is removed on routes outside the whitelist, or when no `.scene-card` is in the DOM.

## Test plan
- [ ] Picking mode on → launcher appears on `/scenes`, `/scenes/markers`, scene detail.
- [ ] Picking mode on → launcher is gone on `/settings`, `/system`, `/tasks`, root `/`.
- [ ] Filter-add button appears on `/scenes`, `/performers/123`, `/studios/123`, etc. when scene cards are present.
- [ ] Filter-add button is gone on a performer's Images / Galleries tabs.
- [ ] No regression: button still injects on direct landings on `/scenes` and tab switches between scenes <-> images on the same performer page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)